### PR TITLE
chore: pin and bump GitHub Actions to 40-char SHAs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docker:
-    uses: naviteq/github-actions/.github/workflows/docker-build.yaml@main
+    uses: naviteq/github-actions/.github/workflows/docker-build.yaml@5b8826cfc79c3a060cec9b2406886a248ee23fef  # v1.20.9
     with:
       REGISTRY: ghcr.io
       DOCKER_CONTEXT: app
@@ -19,7 +19,7 @@ jobs:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   helm:
-    uses: naviteq/github-actions/.github/workflows/helm-release-github.yaml@main
+    uses: naviteq/github-actions/.github/workflows/helm-release-github.yaml@5b8826cfc79c3a060cec9b2406886a248ee23fef  # v1.20.9
     needs: [docker]
     with:
       chart_path: helm
@@ -31,7 +31,7 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
-    uses: naviteq/github-actions/.github/workflows/create-release.yaml@main
+    uses: naviteq/github-actions/.github/workflows/create-release.yaml@5b8826cfc79c3a060cec9b2406886a248ee23fef  # v1.20.9
     needs:
       - docker
       - helm

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -16,17 +16,17 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
       - name: Python format
-        uses: psf/black@stable
+        uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9  # 26.3.1
         with:
           version: 23.1.0
 
   docker:
-    uses: naviteq/github-actions/.github/workflows/docker-build.yaml@main
+    uses: naviteq/github-actions/.github/workflows/docker-build.yaml@5b8826cfc79c3a060cec9b2406886a248ee23fef  # v1.20.9
     needs: [format]
     with:
       REGISTRY: ghcr.io
@@ -38,7 +38,7 @@ jobs:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   helm:
-    uses: naviteq/github-actions/.github/workflows/helm-release-github.yaml@main
+    uses: naviteq/github-actions/.github/workflows/helm-release-github.yaml@5b8826cfc79c3a060cec9b2406886a248ee23fef  # v1.20.9
     needs: [docker]
     with:
       chart_path: helm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker:
-    uses: naviteq/github-actions/.github/workflows/docker-build.yaml@main
+    uses: naviteq/github-actions/.github/workflows/docker-build.yaml@5b8826cfc79c3a060cec9b2406886a248ee23fef  # v1.20.9
     with:
       REGISTRY: ghcr.io
       DOCKER_CONTEXT: app
@@ -18,7 +18,7 @@ jobs:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   helm:
-    uses: naviteq/github-actions/.github/workflows/helm-release-github.yaml@main
+    uses: naviteq/github-actions/.github/workflows/helm-release-github.yaml@5b8826cfc79c3a060cec9b2406886a248ee23fef  # v1.20.9
     needs: [docker]
     with:
       chart_path: helm

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Helm values (see `helm/values.yaml`): replica count, image, resources, ingress, 
 ## Development
 
 - **Lint / hooks:** `.pre-commit-config.yaml`
-- **CI:** GitHub Actions build the Docker image and publish the Helm chart (see `.github/workflows/`). Releases are created on version tags (`v*.*.*`).
+- **CI:** GitHub Actions build the Docker image and publish the Helm chart (see `.github/workflows/`). Releases are created on version tags (`v*.*.*`). Actions are pinned by 40-char commit SHA; updates are managed by Renovate (see `renovate.json`).
 
 ## License
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": [
+    "github-actions",
+    "dockerfile",
+    "helmv3"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions updates"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "dockerfile base image updates"
+    },
+    {
+      "matchManagers": ["helmv3"],
+      "groupName": "helm chart updates"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,7 @@
   "extends": ["config:recommended"],
   "enabledManagers": [
     "github-actions",
-    "dockerfile",
-    "helmv3"
+    "dockerfile"
   ],
   "packageRules": [
     {
@@ -14,10 +13,6 @@
     {
       "matchManagers": ["dockerfile"],
       "groupName": "dockerfile base image updates"
-    },
-    {
-      "matchManagers": ["helmv3"],
-      "groupName": "helm chart updates"
     }
   ]
 }


### PR DESCRIPTION
Closes #12 once merged.

## Summary

- Pin every action in `.github/workflows/*.yaml` to a 40-char commit SHA with a trailing `# vX.Y.Z` comment for review hygiene.
- Bump majors where pinning a stale version made no sense: `actions/checkout` v3 → v6.0.2, `actions/setup-python` v3 → v6.2.0, `psf/black` `@stable` → 26.3.1. `naviteq/github-actions` pinned at its current release v1.20.9.
- Add `renovate.json` so future bumps land as grouped Renovate PRs instead of drifting back to mutable tags.

## Definition of Done

- [x] Every third-party action in `.github/workflows/*.yml` pinned to a 40-char commit SHA — `psf/black` pinned to `c6755bb…`.
- [x] Each pinned reference has a comment with the human-readable version (e.g. `# v4.1.1`) for review hygiene — every `uses:` line carries `# vX.Y.Z`.
- [x] First-party (`actions/*`, `github/*`) actions also pinned — `actions/checkout@de0fac2…  # v6.0.2` and `actions/setup-python@a309ff8…  # v6.2.0`.
- [x] Dependabot or equivalent configured to bump pinned SHAs — `renovate.json` added (`config:recommended`, managers grouped per type), mirroring the pattern from `k8s-resource-simulator#2`.
- [x] CI passes after pinning — will be verified by this PR's own `pullrequest.yaml` run.

## Notes

- `helmv3` is not enabled in `renovate.json` yet — the chart has no `dependencies:` block until #11 lands. It will be re-added as part of #11.